### PR TITLE
[JB][no-ticket] small bug fix for amountInPence

### DIFF
--- a/cor-journey/src/main/scala/essttp/rootmodel/AmountInPence.scala
+++ b/cor-journey/src/main/scala/essttp/rootmodel/AmountInPence.scala
@@ -40,10 +40,10 @@ object AmountInPence {
   def apply(str: String): AmountInPence = {
     str match {
       case s if s.isEmpty => AmountInPence(0)
-      case s              => AmountInPence(BigDecimal(s).longValue() * 100)
+      case s              => AmountInPence((BigDecimal(s) * 100).longValue())
     }
   }
-  def apply(bigDecimal: BigDecimal): AmountInPence = AmountInPence(bigDecimal.longValue() * 100)
+  def apply(bigDecimal: BigDecimal): AmountInPence = AmountInPence((bigDecimal * 100).longValue())
 
   val zero: AmountInPence = AmountInPence(0)
 


### PR DESCRIPTION
From scala doc:
Converts this BigDecimal to a Long. If the BigDecimal is too big to fit in a Long, only the low-order 64 bits are returned. Note that this conversion can lose information about the overall magnitude of the BigDecimal value as well as return a result with the opposite sign.

We were losing the pennies